### PR TITLE
Implement hook_node_delete

### DIFF
--- a/html--shorthand-story.tpl.php
+++ b/html--shorthand-story.tpl.php
@@ -62,5 +62,10 @@
   <?php print $page_top; ?>
   <?php print $page; ?>
   <?php print $page_bottom; ?>
+
+  <?php if (isset($footer_scripts)): ?>
+    <?php print $footer_scripts; ?>
+  <?php endif; ?>
+
 </body>
 </html>

--- a/includes/api.php
+++ b/includes/api.php
@@ -91,7 +91,7 @@ function sh_get_stories() {
 function sh_copy_story($node_id, $story_id) {
   $destination = drupal_realpath('public://');
   $destination_path = $destination . '/shorthand/' . $node_id . '/' . $story_id;
-  $destination_url = file_create_url('public://') . '/shorthand/' . $node_id . '/' . $story_id;
+  $destination_url = file_create_url('public://') . 'shorthand/' . $node_id . '/' . $story_id;
 
   $serverURL = variable_get('shorthand_server_url', 'https://app.shorthand.com');
   $token = variable_get('shorthand_token', '');

--- a/shorthand.admin.inc
+++ b/shorthand.admin.inc
@@ -25,7 +25,7 @@ function shorthand_admin_settings($form, &$form_state) {
   );
   $form['shorthand_token'] = array(
     '#type' => 'textfield',
-    '#title' => t('Shorthand Token'),
+    '#title' => t('API Token'),
     '#default_value' => variable_get('shorthand_token', ''),
     '#size' => 30,
     '#maxlength' => 30,

--- a/shorthand.module
+++ b/shorthand.module
@@ -122,6 +122,16 @@ function update_node_data($node) {
 }
 
 /**
+ * Implements hook_node_delete().
+ */
+function shorthand_node_delete($node) {
+  $story_path = drupal_realpath('public://') . '/shorthand/' . $node->uid . '/' . $node->shorthand_story_id[$node->language][0]['value'];
+  if (file_exists($story_path)) {
+    file_unmanaged_delete_recursive($story_path);
+  }
+}
+
+/**
  * Helper function to fix paths in the shorthand story.
  *
  * @param string $assets_path

--- a/shorthand.module
+++ b/shorthand.module
@@ -115,12 +115,12 @@ function update_node_data($node) {
 
     $head = _shorthand_fix_content_paths($story['url'], file_get_contents($story['path'] . '/component_head.html'));
     // Allow modules to implement hook_shorthand_story_head_alter
-    drupal_alter('shorthand_story_head', $head);
+    drupal_alter('shorthand_story_head', $head, $node->nid);
     $node->shorthand_story_head[LANGUAGE_NONE][0]['value'] = $head;
 
     $body = _shorthand_fix_content_paths($story['url'], file_get_contents($story['path'] . '/component_article.html'));
     // Allow modules to implement hook_shorthand_story_body_alter
-    drupal_alter('shorthand_story_body', $body);
+    drupal_alter('shorthand_story_body', $body, $node->nid);
     $node->shorthand_story_body[LANGUAGE_NONE][0]['value'] = $body;
 
     field_attach_update('node', $node);

--- a/shorthand.module
+++ b/shorthand.module
@@ -110,13 +110,12 @@ function shorthand_node_update($node) {
 function update_node_data($node) {
   if (isset($node->shorthand_story_id)) {
     $node->original = isset($node->original) ? $node->original : NULL;
-    $shorthand_id = $node->shorthand_story_id[$node->language][0]['value'];
-    $node_id = $node->uid;
-    $story = sh_copy_story($node_id, $shorthand_id);
-    $head = _shorthand_fix_content_paths($story['url'], file_get_contents($story['path'] . '/component_head.html'));
-    $node->shorthand_story_head[$node->language][0]['value'] = $head;
-    $body = _shorthand_fix_content_paths($story['url'], file_get_contents($story['path'] . '/component_article.html'));
-    $node->shorthand_story_body[$node->language][0]['value'] = $body;
+
+    $story = sh_copy_story($node->nid, $node->shorthand_story_id[$node->language][0]['value']);
+
+    $node->shorthand_story_head[$node->language][0]['value'] = _shorthand_fix_content_paths($story['url'], file_get_contents($story['path'] . '/component_head.html'));
+    $node->shorthand_story_body[$node->language][0]['value'] = _shorthand_fix_content_paths($story['url'], file_get_contents($story['path'] . '/component_article.html'));
+
     field_attach_update('node', $node);
   }
 }
@@ -125,7 +124,7 @@ function update_node_data($node) {
  * Implements hook_node_delete().
  */
 function shorthand_node_delete($node) {
-  $story_path = drupal_realpath('public://') . '/shorthand/' . $node->uid . '/' . $node->shorthand_story_id[$node->language][0]['value'];
+  $story_path = drupal_realpath('public://') . '/shorthand/' . $node->nid . '/' . $node->shorthand_story_id[$node->language][0]['value'];
   if (file_exists($story_path)) {
     file_unmanaged_delete_recursive($story_path);
   }
@@ -182,7 +181,7 @@ function shorthand_preprocess_html(&$vars) {
       'weight' => 1000,
     ));
 
-    if ($node->shorthand_story_head[LANGUAGE_NONE][0]['value']) {
+    if (!empty($node->shorthand_story_head[LANGUAGE_NONE][0]['value'])) {
       $vars['shorthand_story_head'] = $node->shorthand_story_head[LANGUAGE_NONE][0]['value'];
     }
 

--- a/shorthand.module
+++ b/shorthand.module
@@ -113,8 +113,15 @@ function update_node_data($node) {
 
     $story = sh_copy_story($node->nid, $node->shorthand_story_id[LANGUAGE_NONE][0]['value']);
 
-    $node->shorthand_story_head[LANGUAGE_NONE][0]['value'] = _shorthand_fix_content_paths($story['url'], file_get_contents($story['path'] . '/component_head.html'));
-    $node->shorthand_story_body[LANGUAGE_NONE][0]['value'] = _shorthand_fix_content_paths($story['url'], file_get_contents($story['path'] . '/component_article.html'));
+    $head = _shorthand_fix_content_paths($story['url'], file_get_contents($story['path'] . '/component_head.html'));
+    // Allow modules to implement hook_shorthand_story_head_alter
+    drupal_alter('shorthand_story_head', $head);
+    $node->shorthand_story_head[LANGUAGE_NONE][0]['value'] = $head;
+
+    $body = _shorthand_fix_content_paths($story['url'], file_get_contents($story['path'] . '/component_article.html'));
+    // Allow modules to implement hook_shorthand_story_body_alter
+    drupal_alter('shorthand_story_body', $body);
+    $node->shorthand_story_body[LANGUAGE_NONE][0]['value'] = $body;
 
     field_attach_update('node', $node);
   }

--- a/shorthand.module
+++ b/shorthand.module
@@ -111,10 +111,10 @@ function update_node_data($node) {
   if (isset($node->shorthand_story_id)) {
     $node->original = isset($node->original) ? $node->original : NULL;
 
-    $story = sh_copy_story($node->nid, $node->shorthand_story_id[$node->language][0]['value']);
+    $story = sh_copy_story($node->nid, $node->shorthand_story_id[LANGUAGE_NONE][0]['value']);
 
-    $node->shorthand_story_head[$node->language][0]['value'] = _shorthand_fix_content_paths($story['url'], file_get_contents($story['path'] . '/component_head.html'));
-    $node->shorthand_story_body[$node->language][0]['value'] = _shorthand_fix_content_paths($story['url'], file_get_contents($story['path'] . '/component_article.html'));
+    $node->shorthand_story_head[LANGUAGE_NONE][0]['value'] = _shorthand_fix_content_paths($story['url'], file_get_contents($story['path'] . '/component_head.html'));
+    $node->shorthand_story_body[LANGUAGE_NONE][0]['value'] = _shorthand_fix_content_paths($story['url'], file_get_contents($story['path'] . '/component_article.html'));
 
     field_attach_update('node', $node);
   }
@@ -124,7 +124,7 @@ function update_node_data($node) {
  * Implements hook_node_delete().
  */
 function shorthand_node_delete($node) {
-  $story_path = drupal_realpath('public://') . '/shorthand/' . $node->nid . '/' . $node->shorthand_story_id[$node->language][0]['value'];
+  $story_path = drupal_realpath('public://') . '/shorthand/' . $node->nid . '/' . $node->shorthand_story_id[LANGUAGE_NONE][0]['value'];
   if (file_exists($story_path)) {
     file_unmanaged_delete_recursive($story_path);
   }


### PR DESCRIPTION
**Done**

This PR now includes the following:

- Assets are deleted after node has been deleted. See: https://github.com/Shorthand/shorthand_connect_drupal/issues/12
- An extra slash in the assets URL has been fixed
- Bug in path to Shorthand assets in `sites/default/files` - using UID instead of NID 
- Allow modules to implement hook_shorthand_story_head_alter and hook_shorthand_story_body_alter