### PR TITLE
add extra fields for meta data and added catch for body meta tags

### DIFF
--- a/_docker/README.md
+++ b/_docker/README.md
@@ -1,9 +1,10 @@
-Drupal 7 docker 
+Drupal 7 docker
 
 ```
 # Start environment (from root directory).
 docker-compose --file _docker/docker-compose.yml up --detach --build
 ```
+
 Website is available at [0.0.0.0:7171](http://0.0.0.0:7171).
 
 ```
@@ -11,7 +12,11 @@ Website is available at [0.0.0.0:7171](http://0.0.0.0:7171).
 docker-compose --file _docker/docker-compose.yml exec web bash -c "php -r \"copy('https://getcomposer.org/installer', 'composer-setup.php');\" && php composer-setup.php --install-dir=/usr/local/bin/ --filename=composer && php -r \"unlink('composer-setup.php');\""
 
 # Install drush.
-docker-compose --file _docker/docker-compose.yml exec web bash -c "composer init --quiet && composer require drush/drush:~8"
+docker-compose --file _docker/docker-compose.yml exec web bash -c "composer init --name "shorthand/connect" --quiet && composer require drush/drush:~8"
+
+# Install Sendmail if the image doesn't have it.
+docker-compose --file _docker/docker-compose.yml exec web bash -c "apt-get update && apt-get install sendmail -y"
+
 
 # Install drupal, reset admin password (user admin, password `drupal`) and enable shorthand.
 docker-compose --file _docker/docker-compose.yml exec web bash -c "apt-get update && apt-get install -y default-mysql-client vim git && cp sites/default/default.settings.php sites/default/settings.php && chmod 777 sites/default/settings.php && ./vendor/bin/drush -l default site-install standard -y --db-url='mysql://root:rootp@mysql/mysqldb' && ./vendor/bin/drush -l default vset site_name -y 'Shorthand 7' && ./vendor/bin/drush -l default pm-enable -y shorthand && ./vendor/bin/drush -l default  -y upwd --password='drupal' 'admin' && mkdir -p sites/default/files && chmod 777 -R sites/default/files && ./vendor/bin/drush -l default cache-clear all && ./vendor/bin/drush -l 0.0.0.0:7171 user-login"

--- a/_docker/docker-compose.yml
+++ b/_docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   mysql:
     image: mysql:5.7
@@ -11,6 +11,8 @@ services:
       - MYSQL_DATABASE=mysqldb
       - MYSQL_ROOT_PASSWORD=rootp
     restart: always
+    ports:
+      - "3307:3306"
   web:
     image: drupal:7
     environment:

--- a/field_widget_form.js
+++ b/field_widget_form.js
@@ -3,55 +3,101 @@
  */
 
 jQuery(document).ready(function () {
-  var currentVersion = shStoryData['version'];
+  var currentVersion = shStoryData["version"];
   var showArchivedStories = false;
-  var $shorthandStoryDiv = jQuery('.field-name-shorthand-story-id');
+  var $shorthandStoryDiv = jQuery(".field-name-shorthand-story-id");
 
   $shorthandStoryDiv.each(function () {
-    var existingID = jQuery(this).find('input[type=text]').val();
+    var existingID = jQuery(this).find("input[type=text]").val();
     var foundValidStory = existingID ? false : true;
-    if (jQuery(this).find('ul.stories')) {
+    if (jQuery(this).find("ul.stories")) {
       jQuery(this).append('<ul class="stories"></ul>');
-      var list = jQuery(this).find('ul.stories');
+      var list = jQuery(this).find("ul.stories");
       jQuery(this).append('<div class="clear"></div>');
-      for (var shStory in shStoryData['stories']) {
-        var data = shStoryData['stories'][shStory];
-        var archivedMessage = '';
-        if (shStoryData['version'] !== 'v2' && currentVersion === 'v2' && !showArchivedStories) {
+      for (var shStory in shStoryData["stories"]) {
+        var data = shStoryData["stories"][shStory];
+        var archivedMessage = "";
+        if (
+          shStoryData["version"] !== "v2" &&
+          currentVersion === "v2" &&
+          !showArchivedStories
+        ) {
           continue;
         }
 
-        var serverURL = shStoryData['serverURL'];
+        var serverURL = shStoryData["serverURL"];
         var imageURL = data.image;
-        if (shStoryData['version'] !== 'v2') {
+        if (shStoryData["version"] !== "v2") {
           imageURL = serverURL + data.image;
-          if (currentVersion === 'v2') {
-            archivedMessage = ' (archived)';
+          if (currentVersion === "v2") {
+            archivedMessage = " (archived)";
           }
         }
 
-        var selected = '';
-        var storySelected = '';
+        var selected = "";
+        var storySelected = "";
         if (existingID && existingID == data.id) {
-          selected = 'checked';
-          storySelected = 'selected';
+          selected = "checked";
+          storySelected = "selected";
           foundValidStory = true;
         }
-        list.append('<li class="story ' + storySelected + '"><label><input name="story_id" type="radio" value="' + data.id + '" ' + selected + ' /><img width="150" src="' + imageURL + '" /><span>' + data.title + archivedMessage + '</span></a></label></li>');
+        list.append(
+          '<li class="story ' +
+            storySelected +
+            '"><label><input name="story_id" type="radio" value="' +
+            data.id +
+            '" ' +
+            selected +
+            ' /><img width="150" src="' +
+            imageURL +
+            '" /><span>' +
+            data.title +
+            archivedMessage +
+            "</span><div id='data' style='display:none'>" +
+            // JSON string of all data for the story
+            JSON.stringify(data) +
+            "</div></a></label></li>"
+        );
       }
     }
-    if (!foundValidStory || !shStoryData['stories']) {
-      jQuery(this).find('ul.stories').html('<div class="story_not_found"><h3>Could not find this story to edit, cannot update!  Updating disabled.</h3><p>Please check that you are using the correct API version, and that the story exists in Shorthand and try again.</p></div>');
-      jQuery("#edit-submit").prop('disabled', true);
+    if (!foundValidStory || !shStoryData["stories"]) {
+      jQuery(this)
+        .find("ul.stories")
+        .html(
+          '<div class="story_not_found"><h3>Could not find this story to edit, cannot update!  Updating disabled.</h3><p>Please check that you are using the correct API version, and that the story exists in Shorthand and try again.</p></div>'
+        );
+      jQuery("#edit-submit").prop("disabled", true);
     }
   });
 
-  jQuery('li.story input:radio').click(function () {
-    jQuery('li.story').removeClass('selected');
-    jQuery(this).parent().parent().addClass('selected');
-    jQuery('label#title-prompt-text').text('');
-    var input = jQuery(this).parent().parent().parent().parent().find('input[type=text]');
+  jQuery("li.story input:radio").click(function () {
+    jQuery("li.story").removeClass("selected");
+    jQuery(this).parent().parent().addClass("selected");
+    jQuery("label#title-prompt-text").text("");
+    var input = jQuery(this)
+      .parent()
+      .parent()
+      .parent()
+      .parent()
+      .find("input[type=text]");
     input.val(jQuery(this).val());
-    jQuery('input#edit-title').val(jQuery(this).parent().find('span').text());
+
+    // extract story data and convert to object.
+    var story = JSON.parse(jQuery(this).parent().find("#data")[0].innerHTML);
+
+    // store the form Jquery object so we don't keep traversing the DOM
+    var form = jQuery("#shorthand-story-node-form");
+
+    form.find("input[name='title']").val(story.title);
+    form.find("input[name*='shorthand_story_thumbnail']").val(story.image);
+    form
+      .find("input[name*='shorthand_story_description']")
+      .val(story.metadata.description);
+    form
+      .find("input[name*='shorthand_story_keywords']")
+      .val(story.metadata.keywords);
+    form
+      .find("input[name*='shorthand_story_authors']")
+      .val(story.metadata.authors);
   });
 });

--- a/includes/api-v2.php
+++ b/includes/api-v2.php
@@ -20,7 +20,10 @@ function sh_is_token_valid($token) {
     $url = $serverURL . '/v2/token-info';
     $response = drupal_http_request($url, [
       'method' => 'GET',
-      'headers' => ['Content-Type' => 'application/x-www-form-urlencoded', 'Authorization' => 'Token ' . $token],
+      'headers' => [
+        'Content-Type' => 'application/x-www-form-urlencoded',
+        'Authorization' => 'Token ' . $token,
+      ],
     ]);
     return $response->code == '200';
   }
@@ -46,7 +49,10 @@ function sh_get_stories() {
     $url = $serverURL . '/v2/stories/';
     $response = drupal_http_request($url, [
       'method' => 'GET',
-      'headers' => ['Content-Type' => 'application/x-www-form-urlencoded', 'Authorization' => 'Token ' . $token],
+      'headers' => [
+        'Content-Type' => 'application/x-www-form-urlencoded',
+        'Authorization' => 'Token ' . $token,
+      ],
     ]);
     if (isset($response->data)) {
       $data = json_decode($response->data);
@@ -61,11 +67,21 @@ function sh_get_stories() {
           if (isset($storydata->description)) {
             $description = $storydata->description;
           }
+          $authors = '';
+          if (isset($storydata->authors)) {
+            $authors = $storydata->authors;
+          }
+          $keywords = '';
+          if (isset($storydata->keywords)) {
+            $keywords = $storydata->keywords;
+          }
           $story = [
             'image' => $storydata->cover,
             'id' => $storydata->id,
             'metadata' => (object) [
               'description' => $description,
+              'authors' => $authors,
+              'keywords' => $keywords,
             ],
             'title' => $storydata->title,
           ];

--- a/node--shorthand-story.tpl.php
+++ b/node--shorthand-story.tpl.php
@@ -26,6 +26,12 @@
   <div class="content clearfix"<?php print $content_attributes; ?>>
 
       <?php if(!empty($story_id)): ?>
+        <?php
+        $story_body = preg_replace('/<link.*rel="amphtml"(.[^>]*>)\n/', '', $story_body);
+        $story_body = preg_replace('/<meta property="og:[a-z]+" content=".*">\n/', '', $story_body);
+        $story_body = preg_replace('/<meta name="twitter:[a-z]+" content=".*">\n/', '', $story_body);
+        ?>
+        
         <?php print $story_body; ?>
         <?php print $story_extra_html; ?>
       <?php endif; ?>

--- a/shorthand.install
+++ b/shorthand.install
@@ -154,6 +154,103 @@ function shorthand_install() {
   if (module_exists('i18n')) {
     variable_set('i18n_node_options_shorthand_story', ['current', 'required']);
   }
+
+  // Description / Subtitle.
+  $field_info = field_info_field('shorthand_story_description');
+  $field_instance = field_info_instance('node', 'shorthand_story_description', 'shorthand_story');
+  if (empty($field_info)) {
+    $field = [
+      'field_name' => 'shorthand_story_description',
+      'type' => 'text',
+      'entity_types' => ['node'],
+      'weight' => 1,
+    ];
+    field_create_field($field);
+  }
+
+  if (empty($field_instance)) {
+    $instance = [
+      'field_name' => 'shorthand_story_description',
+      'entity_type' => 'node',
+      'bundle' => 'shorthand_story',
+      'label' => $t('Shorthand Story Description/Subtitle'),
+      'widget' => ['type' => 'text_textfield', 'weight' => 1],
+    ];
+    field_create_instance($instance);
+  }
+
+  // Authors.
+  $field_info = field_info_field('shorthand_story_authors');
+  $field_instance = field_info_instance('node', 'shorthand_story_authors', 'shorthand_story');
+  if (empty($field_info)) {
+    $field = [
+      'field_name' => 'shorthand_story_authors',
+      'type' => 'text',
+      'entity_types' => ['node'],
+      'weight' => 1,
+    ];
+    field_create_field($field);
+  }
+
+  if (empty($field_instance)) {
+    $instance = [
+      'field_name' => 'shorthand_story_authors',
+      'entity_type' => 'node',
+      'bundle' => 'shorthand_story',
+      'label' => $t('Shorthand Story Authors'),
+      'widget' => ['type' => 'text_textfield', 'weight' => 1],
+    ];
+    field_create_instance($instance);
+  }
+
+  // Keywords.
+  $field_info = field_info_field('shorthand_story_keywords');
+  $field_instance = field_info_instance('node', 'shorthand_story_keywords', 'shorthand_story');
+  if (empty($field_info)) {
+    $field = [
+      'field_name' => 'shorthand_story_keywords',
+      'type' => 'text',
+      'entity_types' => ['node'],
+      'weight' => 1,
+    ];
+    field_create_field($field);
+  }
+
+  if (empty($field_instance)) {
+    $instance = [
+      'field_name' => 'shorthand_story_keywords',
+      'entity_type' => 'node',
+      'bundle' => 'shorthand_story',
+      'label' => $t('Shorthand Story Keywords'),
+      'widget' => ['type' => 'text_textfield', 'weight' => 1],
+    ];
+    field_create_instance($instance);
+  }
+
+  // Thumbnail.
+  $field_info = field_info_field('shorthand_story_thumbnail');
+  $field_instance = field_info_instance('node', 'shorthand_story_thumbnail', 'shorthand_story');
+  if (empty($field_info)) {
+    $field = [
+      'field_name' => 'shorthand_story_thumbnail',
+      'type' => 'text',
+      'entity_types' => ['node'],
+      'weight' => 1,
+      'size' => 'large',
+    ];
+    field_create_field($field);
+  }
+
+  if (empty($field_instance)) {
+    $instance = [
+      'field_name' => 'shorthand_story_thumbnail',
+      'entity_type' => 'node',
+      'bundle' => 'shorthand_story',
+      'label' => $t('Shorthand Story Thumbnail'),
+      'widget' => ['type' => 'text_textfield', 'weight' => 1],
+    ];
+    field_create_instance($instance);
+  }
 }
 
 /**
@@ -183,7 +280,12 @@ function shorthand_uninstall() {
     $field_instances['shorthand_story_extra_html'],
     $field_instances['shorthand_story_head'],
     $field_instances['shorthand_story_body'],
-    $field_instances['shorthand_story_version']
+    $field_instances['shorthand_story_version'],
+    // Extra meta fields.
+    $field_instances['shorthand_story_thumbnail'],
+    $field_instances['shorthand_story_keywords'],
+    $field_instances['shorthand_story_authors'],
+    $field_instances['shorthand_story_description']
   );
   if (!$results && !$field_instances) {
     $fields = [
@@ -192,6 +294,10 @@ function shorthand_uninstall() {
       'shorthand_story_head',
       'shorthand_story_body',
       'shorthand_story_version',
+      'shorthand_story_thumbnail',
+      'shorthand_story_keywords',
+      'shorthand_story_authors',
+      'shorthand_story_description',
     ];
     foreach ($fields as $field) {
       if ($instance = field_info_instance('node', $field, 'shorthand_story')) {
@@ -276,4 +382,109 @@ function shorthand_update_7004() {
   variable_set('shorthand_server_v2_url', 'https://api.shorthand.com');
   $t = get_t();
   return $t('Shorthand module has been updated. API v1 has been deprecated. Please update Shorthand settings.');
+}
+
+/**
+ * Adding extra fields for Shorthand Stories.
+ */
+function shorthand_update_7005() {
+
+  $t = get_t();
+
+  // Description / Subtitle.
+  $field_info = field_info_field('shorthand_story_description');
+  $field_instance = field_info_instance('node', 'shorthand_story_description', 'shorthand_story');
+  if (empty($field_info)) {
+    $field = [
+      'field_name' => 'shorthand_story_description',
+      'type' => 'text',
+      'entity_types' => ['node'],
+      'weight' => 1,
+    ];
+    field_create_field($field);
+  }
+
+  if (empty($field_instance)) {
+    $instance = [
+      'field_name' => 'shorthand_story_description',
+      'entity_type' => 'node',
+      'bundle' => 'shorthand_story',
+      'label' => $t('Shorthand Story Description/Subtitle'),
+      'widget' => ['type' => 'text_textfield', 'weight' => 1],
+    ];
+    field_create_instance($instance);
+  }
+
+  // Authors.
+  $field_info = field_info_field('shorthand_story_authors');
+  $field_instance = field_info_instance('node', 'shorthand_story_authors', 'shorthand_story');
+  if (empty($field_info)) {
+    $field = [
+      'field_name' => 'shorthand_story_authors',
+      'type' => 'text',
+      'entity_types' => ['node'],
+      'weight' => 1,
+    ];
+    field_create_field($field);
+  }
+
+  if (empty($field_instance)) {
+    $instance = [
+      'field_name' => 'shorthand_story_authors',
+      'entity_type' => 'node',
+      'bundle' => 'shorthand_story',
+      'label' => $t('Shorthand Story Authors'),
+      'widget' => ['type' => 'text_textfield', 'weight' => 1],
+    ];
+    field_create_instance($instance);
+  }
+
+  // Keywords.
+  $field_info = field_info_field('shorthand_story_keywords');
+  $field_instance = field_info_instance('node', 'shorthand_story_keywords', 'shorthand_story');
+  if (empty($field_info)) {
+    $field = [
+      'field_name' => 'shorthand_story_keywords',
+      'type' => 'text',
+      'entity_types' => ['node'],
+      'weight' => 1,
+    ];
+    field_create_field($field);
+  }
+
+  if (empty($field_instance)) {
+    $instance = [
+      'field_name' => 'shorthand_story_keywords',
+      'entity_type' => 'node',
+      'bundle' => 'shorthand_story',
+      'label' => $t('Shorthand Story Keywords'),
+      'widget' => ['type' => 'text_textfield', 'weight' => 1],
+    ];
+    field_create_instance($instance);
+  }
+
+  // Thumbnail.
+  $field_info = field_info_field('shorthand_story_thumbnail');
+  $field_instance = field_info_instance('node', 'shorthand_story_thumbnail', 'shorthand_story');
+  if (empty($field_info)) {
+    $field = [
+      'field_name' => 'shorthand_story_thumbnail',
+      'type' => 'text',
+      'entity_types' => ['node'],
+      'weight' => 1,
+      'size' => 'large',
+    ];
+    field_create_field($field);
+  }
+
+  if (empty($field_instance)) {
+    $instance = [
+      'field_name' => 'shorthand_story_thumbnail',
+      'entity_type' => 'node',
+      'bundle' => 'shorthand_story',
+      'label' => $t('Shorthand Story Thumbnail'),
+      'widget' => ['type' => 'text_textfield', 'weight' => 1],
+    ];
+    field_create_instance($instance);
+  }
 }


### PR DESCRIPTION
### Developer Expectations:

- Stories now have extra fields for meta data; Authors, Description (subtitle), keywords, thumbnail
- Added a safety net to scrape out meta tags from the story body - needs to be properly addressed on the shorthand zip export.
- Updated README install instructions

NB: Some edits are just spaces and quotation swapping due to linting settings for js and md