### PR TITLE
4.0.21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 shorthand_connect/config.php
+.DS_Store

--- a/_docker/Dockerfile
+++ b/_docker/Dockerfile
@@ -1,0 +1,4 @@
+FROM drupal:11
+
+# COPY /certificates  /usr/local/share/ca-certificates/
+# RUN update-ca-certificates

--- a/_docker/README.md
+++ b/_docker/README.md
@@ -1,0 +1,74 @@
+Drupal 9 docker
+
+```
+# If you intend to develop with a local dylan setup - copy the certificates.
+cp -a ../dylan/ops/ci/nginx/certificates/. ./_docker/certificates/
+```
+
+```
+# Start environment (from root directory).
+docker-compose --file _docker/docker-compose.yml up --detach --build
+```
+
+Website is available at [0.0.0.0:9191](http://0.0.0.0:9191).
+
+```
+# Install composer.
+docker-compose --file _docker/docker-compose.yml exec web bash -c "php -r \"copy('https://getcomposer.org/installer', 'composer-setup.php');\" && php composer-setup.php --install-dir=/usr/local/bin/ --filename=composer && php -r \"unlink('composer-setup.php');\""
+
+# Install drush.
+docker-compose --file _docker/docker-compose.yml exec web composer require --dev drush/drush
+
+# Install drupal, reset admin password (user admin, password `drupal`) and enable shorthand.
+docker-compose --file _docker/docker-compose.yml exec web bash -c "apt-get update && apt-get install -y default-mysql-client vim && cp web/sites/default/default.settings.php web/sites/default/settings.php && ./vendor/bin/drush -l default site:install standard -vvv -y --debug --db-url='mysql://root:rootp@mysql/mysqldb' && ./vendor/bin/drush -l default config:set system.site name -y 'Shorthand 9' && ./vendor/bin/drush -l default pm:enable -y shorthand && ./vendor/bin/drush -l default  -y user:password admin 'drupal' && mkdir -p web/sites/default/files && chmod 777 -R web/sites/default/files && ./vendor/bin/drush -l default cache:rebuild && ./vendor/bin/drush -l default user:login --uri='http://0.0.0.0:9191'"
+
+To edit settings run `vi sites/default/settings.php` inside the container.
+
+# To clear cache.
+docker-compose --file _docker/docker-compose.yml exec web ./vendor/bin/drush -l default cache:rebuild
+```
+
+To setup local dylan api interop
+
+```
+#create bridge network
+docker network create drupalDevNetwork
+
+#connect dylan_dev
+docker network connect drupalDevNetwork dev_dylan
+
+#connect web (drupal)
+docker network connect drupalDevNetwork web
+
+#inspect network to see ip address of dylan_dev (in the below command we've assumed 172.18.0.2)
+docker network inspect drupalDevNetwork
+
+#set api.dylan.local in /etc/hosts of drupal container (change 172.18.0.2 if the above ip address shows differently)
+docker-compose --file _docker/docker-compose.yml exec web bash -c "echo '172.18.0.2   api.dylan.local' >> /etc/hosts"
+
+#Ensure the correct api url is being used for local dev - in ShorthandApiv2.php:
+const SHORTHAND_API_URL = 'https://api.dylan.local/';
+```
+
+To run `phpcs` code linting
+
+```
+# Install Drupal code.
+docker-compose --file _docker/docker-compose.yml exec web composer require drupal/coder
+
+# Setup code linting.
+docker-compose --file _docker/docker-compose.yml exec web ./vendor/bin/phpcs --config-set installed_paths /opt/drupal/vendor/drupal/coder/coder_sniffer
+
+# Run code linting.
+docker-compose --file _docker/docker-compose.yml exec web ./vendor/bin/phpcs -p --standard=DrupalPractice,Drupal --extensions=php,module,inc,install,test,profile,theme /opt/drupal/web/modules/custom/shorthand
+
+# Run code fixing.
+docker-compose --file _docker/docker-compose.yml exec web ./vendor/bin/phpcbf -p --standard=DrupalPractice,Drupal --extensions=php,module,inc,install,test,profile,theme /opt/drupal/web/modules/custom/shorthand
+```
+
+To stop and remove containers run
+
+```
+docker-compose --file _docker/docker-compose.yml stop
+docker-compose --file _docker/docker-compose.yml rm -f
+```

--- a/_docker/certificates/README.md
+++ b/_docker/certificates/README.md
@@ -1,0 +1,1 @@
+This folder is used for storing dylan certs to connect to api.dylan.local over https.

--- a/_docker/docker-compose.yml
+++ b/_docker/docker-compose.yml
@@ -1,0 +1,36 @@
+  services:
+    # Postgres
+    db:
+      image: postgres:latest
+      restart: always
+      environment:
+        POSTGRES_DB: drupaldb
+        POSTGRES_USER: drupaluser
+        POSTGRES_PASSWORD: drupalpassword
+      volumes:
+        - db_data:/var/lib/postgresql/data
+      ports:
+        - 5432:5432
+    
+    # Drupal
+    cms:
+      image: drupal:latest
+      restart: always
+      ports:
+        - 9191:80
+      volumes:
+        - cms_modules:/var/www/html/modules
+        - cms_profiles:/var/www/html/profiles
+        - cms_themes:/var/www/html/themes
+        - cms_sites:/var/www/html/sites
+        - ..:/var/www/html/modules/custom/shorthand
+      depends_on:
+        - db
+    
+  # Volumes
+  volumes:
+    db_data:
+    cms_modules:
+    cms_profiles:
+    cms_themes:
+    cms_sites:

--- a/resources/js/shorthand-form.js
+++ b/resources/js/shorthand-form.js
@@ -27,7 +27,10 @@ function filterStories(filter) {
   });
 }
 
-storyFilter.addEventListener('keyup', () => {
-  const filter = storyFilter.value;
-  filterStories(filter.toLowerCase());
-});
+if(storyFilter){
+  storyFilter.addEventListener('keyup', () => {
+    const filter = storyFilter.value;
+    filterStories(filter.toLowerCase());
+  });
+}
+

--- a/resources/js/shorthand-selection-form.js
+++ b/resources/js/shorthand-selection-form.js
@@ -140,10 +140,12 @@ function filterStories(filter) {
     }
   });
 }
-
-storyFilter.addEventListener('keyup', () => {
-  const filter = storyFilter.value;
-  filterStories(filter.toLowerCase());
-});
+if (storyFilter) {
+  storyFilter.addEventListener('keyup', () => {
+    const filter = storyFilter.value;
+    filterStories(filter.toLowerCase());
+  });
+  
+}
 
 updateSelection();

--- a/shorthand.info.yml
+++ b/shorthand.info.yml
@@ -10,6 +10,6 @@ dependencies:
 configure: shorthand.settings_form
 
 # Information added by Drupal.org packaging script on 2025-03-31
-version: '4.0.20'
-project: 'shorthand'
-datestamp: 1743430629
+version: "4.0.21"
+project: "shorthand"
+datestamp: 1744017988

--- a/src/Entity/ShorthandStory.php
+++ b/src/Entity/ShorthandStory.php
@@ -24,6 +24,12 @@ use Drupal\user\UserInterface;
  *     "list_builder" = "Drupal\shorthand\ShorthandStoryListBuilder",
  *     "views_data" = "Drupal\shorthand\Entity\ShorthandStoryViewsData",
  *     "translation" = "Drupal\shorthand\ShorthandStoryTranslationHandler",
+ *     "form" = {
+ *       "default" = "Drupal\shorthand\Form\ShorthandStoryForm",
+ *       "add" = "Drupal\shorthand\Form\ShorthandStoryForm",
+ *       "edit" = "Drupal\shorthand\Form\ShorthandStoryForm", 
+ *       "delete" = "Drupal\shorthand\Form\ShorthandStoryDeleteForm",
+ *     },
  *     "access" = "Drupal\shorthand\ShorthandStoryAccessControlHandler",
  *     "route_provider" = {
  *       "html" = "Drupal\shorthand\ShorthandStoryHtmlRouteProvider",
@@ -50,6 +56,8 @@ use Drupal\user\UserInterface;
  *     "revision_log_message" = "revision_log_message",
  *   },
  *   links = {
+ *     "edit-form" = "/admin/content/shorthand-story/{shorthand_story}/edit",
+ *     "delete-form" = "/admin/content/shorthand-story/{shorthand_story}/delete",
  *     "canonical" = "/shorthand-story/{shorthand_story}",
  *     "version-history" = "/admin/content/shorthand-story/{shorthand_story}/revisions",
  *     "revision" = "/admin/content/shorthand-story/{shorthand_story}/revisions/{shorthand_story_revision}/view",
@@ -60,6 +68,7 @@ use Drupal\user\UserInterface;
  *
  * @deprecated in shorthand:4.0.0 and is removed from shorthand:5.0.0. Use shorthand field.
  *
+ * 
  * @see https://www.drupal.org/project/shorthand/issues/3274487
  */
 class ShorthandStory extends RevisionableContentEntityBase implements ShorthandStoryInterface {

--- a/src/Form/ShorthandStoryDeleteForm.php
+++ b/src/Form/ShorthandStoryDeleteForm.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Drupal\shorthand\Form;
+
+use Drupal\Core\Entity\ContentEntityDeleteForm;
+
+/**
+ * Provides a form for deleting Shorthand story entities.
+ *
+ * @ingroup shorthand
+ */
+class ShorthandStoryDeleteForm extends ContentEntityDeleteForm {
+
+
+}

--- a/src/Form/ShorthandStoryForm.php
+++ b/src/Form/ShorthandStoryForm.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Drupal\shorthand\Form;
+
+use Drupal\Component\Datetime\TimeInterface;
+use Drupal\Core\Entity\ContentEntityForm;
+use Drupal\Core\Entity\EntityRepositoryInterface;
+use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Form controller for Shorthand story edit forms.
+ *
+ * @ingroup shorthand
+ */
+class ShorthandStoryForm extends ContentEntityForm {
+
+  /**
+   * The book being displayed.
+   *
+   * @var \Drupal\shorthand\Entity\ShorthandStory
+   */
+  protected $entity;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
+   * The time service.
+   *
+   * @var \Drupal\Component\Datetime\TimeInterface
+   */
+  protected $time;
+
+  /**
+   * The messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * The logger instance.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected $logger;
+
+  /**
+   * Initializes an instance of the Shorthand story.
+   *
+   * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
+   *   The entity repository.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
+   *   The entity type bundle service.
+   * @param \Drupal\Component\Datetime\TimeInterface $time
+   *   The time service.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   The current user.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger interface.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   The logger instance.
+   * @param Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   Config factory instance.
+   */
+  public function __construct(EntityRepositoryInterface $entity_repository,
+    EntityTypeBundleInfoInterface $entity_type_bundle_info = NULL,
+    TimeInterface $time = NULL,
+    AccountInterface $current_user,
+    MessengerInterface $messenger,
+    LoggerInterface $logger,
+    ConfigFactoryInterface $config_factory) {
+    parent::__construct($entity_repository, $entity_type_bundle_info, $time, $config_factory);
+    $this->currentUser = $current_user;
+    $this->time = $time;
+    $this->messenger = $messenger;
+    $this->logger = $logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity.repository'),
+      $container->get('entity_type.bundle.info'),
+      $container->get('datetime.time'),
+      $container->get('current_user'),
+      $container->get('messenger'),
+      $container->get('logger.channel.shorthand'),
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    /** @var \Drupal\shorthand\Entity\ShorthandStory $entity */
+    $form = parent::buildForm($form, $form_state);
+    $form['#attached']['library'][] = 'shorthand/shorthandForm';
+
+    if (!$this->entity->isNew()) {
+      $form['new_revision'] = [
+        '#type' => 'checkbox',
+        '#title' => $this->t('Create new revision'),
+        '#default_value' => FALSE,
+        '#weight' => 10,
+      ];
+    }
+
+    // Check formats.
+    $formats = array_keys(filter_formats());
+    $config = $this->config('shorthand.settings');
+    $input_format = $config->get('input_format', filter_default_format());
+
+    $format_fail = !in_array($input_format, $formats);
+    $load_fail = ($form['shorthand_id']['widget'][0]['value']['#options'] == [0 => "Cannot retrieve stories"]);
+
+    if ($format_fail) {
+      $error = $this->t('The <em>shorthand_input_format</em> setting value <em>@format</em> does not match existing text format. It should be one of the following: <strong>@formats</strong>', [
+        '@format' => $input_format,
+        '@formats' => implode(', ', $formats),
+      ]);
+      $this->messenger->addError($error);
+      $this->logger->error($error);
+    }
+
+    if ($format_fail || $load_fail) {
+      return new RedirectResponse('/admin/content/shorthand-story');
+    }
+    else {
+      return $form;
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function save(array $form, FormStateInterface $form_state) {
+    $entity = &$this->entity;
+
+    // Save as a new revision if requested to do so.
+    if (!$form_state->isValueEmpty('new_revision') && $form_state->getValue('new_revision') != FALSE) {
+      $entity->setNewRevision();
+
+      // If a new revision is created, save the current user as revision author.
+      $entity->setRevisionCreationTime($this->time->getRequestTime());
+      $entity->setRevisionUserId($this->currentUser->id());
+    }
+    else {
+      $entity->setNewRevision(FALSE);
+    }
+
+    $status = parent::save($form, $form_state);
+
+    switch ($status) {
+      case SAVED_NEW:
+        $this->messenger()->addStatus($this->t('Created the %label Shorthand story.', [
+          '%label' => $entity->label(),
+        ]));
+        break;
+
+      default:
+        $this->messenger()->addStatus($this->t('Saved the %label Shorthand story.', [
+          '%label' => $entity->label(),
+        ]));
+    }
+    $form_state->setRedirect('entity.shorthand_story.canonical', ['shorthand_story' => $entity->id()]);
+  }
+
+}

--- a/src/Plugin/Field/FieldWidget/StorySelectFieldWidget.php
+++ b/src/Plugin/Field/FieldWidget/StorySelectFieldWidget.php
@@ -88,7 +88,7 @@ class StorySelectFieldWidget extends WidgetBase implements ContainerFactoryPlugi
       '#type' => 'select',
       '#default_value' => $items[$delta]->value ?? NULL,
       '#options' => $this->buildStoriesList(),
-      '#suffix' => '<div id="shorthand-stories-data">' . json_encode($this->shorthandStories) . '</div>',
+      '#suffix' => '<div id="shorthand-stories-data" hidden>' . json_encode($this->shorthandStories) . '</div>',
     ];
 
     return $element;


### PR DESCRIPTION
Issue:
Upgrading from version 8.x-2.11 to 4.0.X removes functionality that should be present to allow Drupal admins to  moderate content rendering the content stuck on their website without the ability to edit/delete.

Testing steps:

- Install Drupal version 10.4.6 
- Install Shorthand Drupal 8.x-2.11
- Insert the API key under 'Configure'
- Pull a story into Drupal (I recommend pulling 2/3)
- Observe under Content -> Shorthand there is an edit/delete button in the table
- Upgrade the plugin to the latest version (4.0.20)
- Install Shorthand Example (Plugin under Extend)
- Insert the API key again into Configure -> Web Services
- Under Content -> Shorthand (Deprecated) you will see the previously pulled stories with no options to edit/delete 
- Upgrade the plugin to this branch (Replace the files with these)
- Observe that under Shorthand (Deprecated) the edit & delete button is present again


**Things we won't fix:**
- On the Shorthand (Deprecated) page, there will be an output of links for the images; we won't fix this as this area is obsolete now.